### PR TITLE
chore: redirect actions to freshaengineering + pin to SHA

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,13 +1,13 @@
 version: 1
-generated_at: 2026-05-25T15:54:04Z
+generated_at: 2026-06-11T15:39:18Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
+      - 34e114876b0b11c390a56381ad16ebd13914f8d5
       - v2
-      - v4
     occurrences:
-      v4:
+      34e114876b0b11c390a56381ad16ebd13914f8d5:
         .github/actions/github-actions/release-action/action.yml:
           - runs.steps.[0].uses
         .github/workflows/action-release copy.yaml:
@@ -21,9 +21,9 @@ trusted:
           - jobs.merge-gatekeeper.steps.[0].uses
   - action: actions/github-script
     refs:
-      - v7
+      - f28e40c7f34bde8b3046d885e986cb6290c5673b
     occurrences:
-      v7:
+      f28e40c7f34bde8b3046d885e986cb6290c5673b:
         .github/actions/github-actions/release-action/action.yml:
           - runs.steps.[5].uses
           - runs.steps.[6].uses
@@ -39,9 +39,9 @@ trusted:
           - jobs.build.steps.[1].uses
   - action: actions/setup-node
     refs:
-      - v4
+      - 49933ea5288caeca8642d1e84afbd3f7d6820020
     occurrences:
-      v4:
+      49933ea5288caeca8642d1e84afbd3f7d6820020:
         .github/actions/github-actions/release-action/action.yml:
           - runs.steps.[2].uses
         .github/actions/github-actions/validate-return-modified-action/action.yml:

--- a/.github/actions/github-actions/release-action/action.yml
+++ b/.github/actions/github-actions/release-action/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
@@ -27,7 +27,7 @@ runs:
       uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 20
 
@@ -46,7 +46,7 @@ runs:
 
     - name: Handle action directory validation failure
       if: failure()
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const errorMsg = '${{ steps.find-action.outputs.error }}' || 'Action validation failed';
@@ -65,7 +65,7 @@ runs:
 
     - name: Dismiss PR change requests if all OK
       if: inputs.mode == 'check' && steps.find-action.outputs.error == ''
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const reviews = await github.rest.pulls.listReviews({
@@ -89,7 +89,7 @@ runs:
     - name: Determine release info
       if: inputs.mode == 'release' && steps.find-action.outputs.modified_action != ''
       id: release-info
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const { execSync } = require('child_process');

--- a/.github/actions/github-actions/validate-return-modified-action/action.yml
+++ b/.github/actions/github-actions/validate-return-modified-action/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 20
 
@@ -33,7 +33,7 @@ runs:
 
     - name: Find and validate action directory
       id: find-action
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
         NODE_PATH: /tmp/action_node_modules/node_modules
       with:

--- a/.github/workflows/action-release copy.yaml
+++ b/.github/workflows/action-release copy.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate action changes
         uses: ./.github/actions/github-actions/release-action

--- a/.github/workflows/action-release.yaml
+++ b/.github/workflows/action-release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Release action changes
         uses: ./.github/actions/github-actions/release-action


### PR DESCRIPTION
## Summary
- Redirects all `surgeventures/platform-tribe-actions` references to `freshaengineering/platform-tribe-actions`
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following 5 commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA