### PR TITLE
chore: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,11 +1,11 @@
 version: 1
-generated_at: 2026-06-11T15:39:18Z
+generated_at: 2026-06-15T13:15:43Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
       - 34e114876b0b11c390a56381ad16ebd13914f8d5
-      - v2
+      - ee0669bd1cc54295c223e0bb666b733df41de1c5
     occurrences:
       34e114876b0b11c390a56381ad16ebd13914f8d5:
         .github/actions/github-actions/release-action/action.yml:
@@ -14,7 +14,7 @@ trusted:
           - jobs.check-changes.steps.[0].uses
         .github/workflows/action-release.yaml:
           - jobs.create-release.steps.[0].uses
-      v2:
+      ee0669bd1cc54295c223e0bb666b733df41de1c5:
         .github/workflows/build-ci.yaml:
           - jobs.build.steps.[0].uses
         .github/workflows/merge-gatekeeper-latest.yaml:

--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.github/workflows/merge-gatekeeper-latest.yaml
+++ b/.github/workflows/merge-gatekeeper-latest.yaml
@@ -14,7 +14,7 @@ jobs:
       statuses: read
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA